### PR TITLE
Add Windows support and expand `human_b`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+`0.6 -> 0.7`
+============
+
+Windows support was added.  It actually took shockingly little effort.
+Tests pass, LaTeX and image generation works.  I also added expanded
+`human_b` support as well as an actual unit-test for `human_b`.
+
+
 `0.5 -> 0.6`
 ============
 

--- a/pylink/__init__.py
+++ b/pylink/__init__.py
@@ -49,7 +49,7 @@ human_m
 
 __title__ = 'pylink'
 __author__ = 'Harrison Caudill <harrison@hypersphere.org>'
-__version__ = '0.6'
+__version__ = '0.7'
 __license__ = 'BSD'
 
 

--- a/pylink/report.py
+++ b/pylink/report.py
@@ -21,13 +21,16 @@ class Figure(object):
         if not fname:
             fname = self.fname()
 
+        # LaTeX does NOT play nicely with backslashes in windows
+        path = os.path.join(dname, fname).replace('\\', '/')
+
         return '''
   \\begin{figure}
     \\caption{%s}
     \\includegraphics[width=\\linewidth]{%s}
     \\label{fig::pfd::%s}
   \\end{figure}
-        ''' % (self.caption(), os.path.join(dname, fname), self.label())
+        ''' % (self.caption(), path, self.label())
 
     def _plot_vs_el(self, y_func, dname='.', fname=None):
         m = self.model

--- a/pylink/utils.py
+++ b/pylink/utils.py
@@ -72,10 +72,12 @@ def human_b(bytes):
     Just to be clear, this will use the 1024 versions, not the 1000
     versions.
     """
-    suffixes = ['TB', 'GB', 'MB', 'kB']
-    for i in range(4):
-        m = 1<<(10*(4-i))
+    suffixes = ['EB', 'PB', 'TB', 'GB', 'MB', 'kB']
+    n = len(suffixes)
+    for i in range(n):
+        m = 1<<(10*(n-i))
         if bytes > m:
+            print(math.log(bytes, 2), bytes / float(m), suffixes[i])
             return (bytes / float(m), suffixes[i])
     return (bytes, 'B')
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ for srcdir, dst in data_dirs.items():
 
 setup(
     name='pylink-satcom',
-    version='0.6',
+    version='0.7',
     author='Harrison Caudill',
     author_email='harrison@hypersphere.org',
     description='Python Link Budget System',

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -35,7 +35,7 @@ class TestUtils(object):
                      1.1e8:  (110.0, 'MHz'),
                      1.1e9:  (1.1,   'GHz'),
                      1.1e10: (11.0,  'GHz'),
-                     1.1e11: (110.0, 'GHz')}.iteritems():
+                     1.1e11: (110.0, 'GHz')}.items():
             good = s
             questionable = pylink.human_hz(v)
             assert abs(good[0] - questionable[0]) < 1e-6
@@ -50,11 +50,45 @@ class TestUtils(object):
                      1.1e1:  (11.0,  'm'),
                      1.1e2:  (110.0, 'm'),
                      1.1e3:  (1.1,   'km'),
-                     1.1e4:  (11.0,  'km'),}.iteritems():
+                     1.1e4:  (11.0,  'km'),}.items():
             good = s
             questionable = pylink.human_m(v)
             assert abs(good[0] - questionable[0]) < 1e-6
             assert good[1] == questionable[1]
+
+    def test_human_b(self):
+        b = 0.11
+        for v, s in {b*1e0*1024**0: (0.11,  'B'),
+                     b*1e1*1024**0: (1.1,   'B'),
+                     b*1e2*1024**0: (11.0,  'B'),
+                     b*1e3*1024**0: (110.0, 'B'),
+                     b*1e1*1024**1: (1.1,   'kB'),
+                     b*1e2*1024**1: (11,    'kB'),
+                     b*1e3*1024**1: (110,   'kB'),
+                     b*1e1*1024**2: (1.1,   'MB'),
+                     b*1e2*1024**2: (11,    'MB'),
+                     b*1e3*1024**2: (110,   'MB'),
+                     b*1e1*1024**3: (1.1,   'GB'),
+                     b*1e2*1024**3: (11,    'GB'),
+                     b*1e3*1024**3: (110,   'GB'),
+                     b*1e1*1024**4: (1.1,   'TB'),
+                     b*1e2*1024**4: (11,    'TB'),
+                     b*1e3*1024**4: (110,   'TB'),
+                     b*1e1*1024**5: (1.1,   'PB'),
+                     b*1e2*1024**5: (11,    'PB'),
+                     b*1e3*1024**5: (110,   'PB'),
+                     b*1e1*1024**6: (1.1,   'EB'),
+                     b*1e2*1024**6: (11,    'EB'),
+                     b*1e3*1024**6: (110,   'EB'),
+                     }.items():
+            good = s
+            questionable = pylink.human_b(v)
+            print(good, questionable)
+            assert abs(good[0] - questionable[0]) < 1e-6
+            assert good[1] == questionable[1]
+
+    suffixes = ['TB', 'GB', 'MB', 'kB']
+
 
     def test_spreading_loss_db(self):
         assert abs(pylink.spreading_loss_db(0.5e-3)


### PR DESCRIPTION
This PR adds support for Windows, and expands/tests the `human_b` function.

The only thing that didn't seem to work in windows was the backslashes in paths in LaTeX files.  Since there was only one place where that was used (`\includegraphics` in Figures) it was an easy fix.

I also expanded the `human_b` function to include Pebibytes and Exbibytes, and added a unit-test for that function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harrison-caudill/pylink/41)
<!-- Reviewable:end -->
